### PR TITLE
Download image demo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ pass it as second parameter into the set function such as:
 * Using SDF fonts - [live example](http://github.alessaska.cz/HelikarLab/ccNetViz/master/examples/sdf.html)
 * User definied layout - [live example](http://github.alessaska.cz/HelikarLab/ccNetViz/master/examples/userdef_layout.html)
 * Edges-to-edges support - [live example](http://github.alessaska.cz/HelikarLab/ccNetViz/master/examples/edges_to_edges.html)
+* Save graphs - [live example](http://github.alessaska.cz/HelikarLab/ccNetViz/master/examples/save_graph.html)
 
 **Documentation**
 

--- a/examples/save_graph.html
+++ b/examples/save_graph.html
@@ -16,6 +16,14 @@
         color: black;
     }
 
+    #down_img {
+      background: #ccc;
+      padding: 5px;
+      margin: 10px 0;
+      display: inline-block;
+      cursor: pointer;
+      border-radius: 3px;
+    }
     </style>
     <script src="./libs/jquery.min.js"></script>
     <script src="./libs/json_prettyprint.js"></script>
@@ -30,7 +38,7 @@
     <div id='body'>
         <canvas id="container"></canvas>
         <br />
-        <button><a id="down_img">Save image</a></button>
+        <a id="down_img">Save image</a>
     </div>
     <script>
 

--- a/examples/save_graph.html
+++ b/examples/save_graph.html
@@ -91,6 +91,10 @@
         $("#confel").empty().append($("<pre />").html(library.json.prettyPrint(conf)));
 
         var el = document.getElementById('container');
+
+        // After drawing keep save to the changes.
+        el.getContext("webgl", { preserveDrawingBuffer: true });
+
         var graph = new ccNetViz(el, conf);
         graph.set(data.nodes, data.edges, "force");
         graph.draw();


### PR DESCRIPTION
Button tag removed, a tags does not work the inside the buttons. (Firefox 65.0.1 (64-bit))

Empty image: preserveDrawingBuffer attribute changed to the true for current canvas.